### PR TITLE
Change module/require export to provide both saveAs and saveTextAs.

### DIFF
--- a/FileSaver.js
+++ b/FileSaver.js
@@ -233,14 +233,6 @@ var saveAs = saveAs
 // while `this` is nsIContentFrameMessageManager
 // with an attribute `content` that corresponds to the window
 
-if (typeof module !== "undefined" && module !== null) {
-    module.exports = saveAs;
-} else if ((typeof define !== "undefined" && define !== null) && (define.amd != null)) {
-    define([], function () {
-        return saveAs;
-    });
-}
-
 String.prototype.endsWithAny = function () {
     var strArray = Array.prototype.slice.call(arguments),
         $this = this.toLowerCase().toString();
@@ -292,4 +284,18 @@ var saveTextAs = saveTextAs
         saveTxtWindow.close();
         return retValue;
     }
-})
+});
+
+var exportObject = {
+    saveAs: saveAs,
+    saveTextAs: saveTextAs
+};
+
+if (typeof module !== "undefined" && module !== null) {
+    module.exports = exportObject
+} else if ((typeof define !== "undefined" && define !== null) && (define.amd != null)) {
+    define([], function () {
+        return exportObject;
+    });
+}
+


### PR DESCRIPTION
This is a breaking change (it moves from exporting `saveAs` directly to exporting an object with `saveAs` and `saveTextAs` as methods on it), however without this change `saveTextAs` is not made available.

As an aside, this also makes code using the functions easier to test in Jasmine, since they can be replaced with test doubles nicely.
